### PR TITLE
VS 2013 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 # User-specific files
 *.suo
-*.user
 *.userosscache
 *.sln.docstates
 
@@ -67,3 +66,7 @@ dlldata.c
 *.ncb
 *.opt
 *.plg
+
+# VC12
+*.sdf
+*.opensdf

--- a/src/3rd/crn_decomp.h
+++ b/src/3rd/crn_decomp.h
@@ -13,6 +13,8 @@
 #ifndef CRND_INCLUDE_CRND_H
 #define CRND_INCLUDE_CRND_H
 
+#define WIN32 1
+
 // definitions from crnlib.h
 // Various library/file format limits.
 typedef enum
@@ -1649,7 +1651,7 @@ namespace crnd
       static uint32        pack_endpoints(uint32 lo, uint32 hi);
    };
 
-   CRND_DEFINE_BITWISE_MOVABLE(dxt1_block);
+   int CRND_DEFINE_BITWISE_MOVABLE(dxt1_block);
 
    struct dxt3_block
    {
@@ -1660,7 +1662,7 @@ namespace crnd
       uint32 get_alpha(uint32 x, uint32 y, bool scaled) const;
    };
 
-   CRND_DEFINE_BITWISE_MOVABLE(dxt3_block);
+   int CRND_DEFINE_BITWISE_MOVABLE(dxt3_block);
 
    struct dxt5_block
    {
@@ -1753,7 +1755,7 @@ namespace crnd
       static uint32          pack_endpoints(uint32 lo, uint32 hi);
    };
 
-   CRND_DEFINE_BITWISE_MOVABLE(dxt5_block);
+   int CRND_DEFINE_BITWISE_MOVABLE(dxt5_block);
 
 } // namespace crnd
 

--- a/src/3rd/crn_decomp.h
+++ b/src/3rd/crn_decomp.h
@@ -13,8 +13,6 @@
 #ifndef CRND_INCLUDE_CRND_H
 #define CRND_INCLUDE_CRND_H
 
-#define WIN32 1
-
 // definitions from crnlib.h
 // Various library/file format limits.
 typedef enum
@@ -1651,7 +1649,7 @@ namespace crnd
       static uint32        pack_endpoints(uint32 lo, uint32 hi);
    };
 
-   int CRND_DEFINE_BITWISE_MOVABLE(dxt1_block);
+   CRND_DEFINE_BITWISE_MOVABLE(dxt1_block);
 
    struct dxt3_block
    {
@@ -1662,7 +1660,7 @@ namespace crnd
       uint32 get_alpha(uint32 x, uint32 y, bool scaled) const;
    };
 
-   int CRND_DEFINE_BITWISE_MOVABLE(dxt3_block);
+   CRND_DEFINE_BITWISE_MOVABLE(dxt3_block);
 
    struct dxt5_block
    {
@@ -1755,7 +1753,7 @@ namespace crnd
       static uint32          pack_endpoints(uint32 lo, uint32 hi);
    };
 
-   int CRND_DEFINE_BITWISE_MOVABLE(dxt5_block);
+   CRND_DEFINE_BITWISE_MOVABLE(dxt5_block);
 
 } // namespace crnd
 

--- a/src/u_noise.c
+++ b/src/u_noise.c
@@ -1,5 +1,6 @@
 #include "u_noise.h"
-#include "caveview.h"
+//#include "caveview.h"
+#include "stb.h"
 #include <string.h>
 #include <math.h> // floor()
 

--- a/vc12/obbg.sln
+++ b/vc12/obbg.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30723.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "obbg", "obbg\obbg.vcxproj", "{C7BA0210-D353-482A-B612-54A607EBB7B1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C7BA0210-D353-482A-B612-54A607EBB7B1}.Debug|Win32.ActiveCfg = Debug|Win32
+		{C7BA0210-D353-482A-B612-54A607EBB7B1}.Debug|Win32.Build.0 = Debug|Win32
+		{C7BA0210-D353-482A-B612-54A607EBB7B1}.Release|Win32.ActiveCfg = Release|Win32
+		{C7BA0210-D353-482A-B612-54A607EBB7B1}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/vc12/obbg/obbg.vcxproj
+++ b/vc12/obbg/obbg.vcxproj
@@ -44,7 +44,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>false</SDLCheck>
-      <AdditionalIncludeDirectories>src;src\win32;src\3rd;$(SolutionDir)..\SDL\include;$(SolutionDir)..\stb</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;src\win32;src\3rd;$(SolutionDir)..\include;$(SolutionDir)..\stb</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
     </ClCompile>
     <Link>
@@ -60,7 +60,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
-      <AdditionalIncludeDirectories>src;src\win32;src\3rd;$(SolutionDir)..\SDL\include;$(SolutionDir)..\stb</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;src\win32;src\3rd;$(SolutionDir)..\include;$(SolutionDir)..\stb</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/vc12/obbg/obbg.vcxproj
+++ b/vc12/obbg/obbg.vcxproj
@@ -1,0 +1,112 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{C7BA0210-D353-482A-B612-54A607EBB7B1}</ProjectGuid>
+    <RootNamespace>obbg</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>false</SDLCheck>
+      <AdditionalIncludeDirectories>src;src\win32;src\3rd;$(SolutionDir)..\SDL\include;$(SolutionDir)..\stb</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>SDL2.lib;SDL2main.lib;opengl32.lib;glu32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)\..\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>false</SDLCheck>
+      <AdditionalIncludeDirectories>src;src\win32;src\3rd;$(SolutionDir)..\SDL\include;$(SolutionDir)..\stb</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>SDL2.lib;SDL2main.lib;opengl32.lib;glu32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)\..\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\3rd\crn_decomp.h" />
+    <ClInclude Include="..\..\src\glext.h" />
+    <ClInclude Include="..\..\src\glext_list.h" />
+    <ClInclude Include="..\..\src\obbg_data.h" />
+    <ClInclude Include="..\..\src\obbg_funcs.h" />
+    <ClInclude Include="..\..\src\stb_gl.h" />
+    <ClInclude Include="..\..\src\stb_glprog.h" />
+    <ClInclude Include="..\..\src\u_noise.h" />
+    <ClInclude Include="..\..\stb\stb.h" />
+    <ClInclude Include="..\..\stb\stb_c_lexer.h" />
+    <ClInclude Include="..\..\stb\stb_divide.h" />
+    <ClInclude Include="..\..\stb\stb_dxt.h" />
+    <ClInclude Include="..\..\stb\stb_easy_font.h" />
+    <ClInclude Include="..\..\stb\stb_herringbone_wang_tile.h" />
+    <ClInclude Include="..\..\stb\stb_image.h" />
+    <ClInclude Include="..\..\stb\stb_image_resize.h" />
+    <ClInclude Include="..\..\stb\stb_image_write.h" />
+    <ClInclude Include="..\..\stb\stb_leakcheck.h" />
+    <ClInclude Include="..\..\stb\stb_perlin.h" />
+    <ClInclude Include="..\..\stb\stb_rect_pack.h" />
+    <ClInclude Include="..\..\stb\stb_textedit.h" />
+    <ClInclude Include="..\..\stb\stb_tilemap_editor.h" />
+    <ClInclude Include="..\..\stb\stb_truetype.h" />
+    <ClInclude Include="..\..\stb\stb_voxel_render.h" />
+    <ClInclude Include="..\..\stb\stretchy_buffer.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\main.c" />
+    <ClCompile Include="..\..\src\mesh_builder.c" />
+    <ClCompile Include="..\..\src\texture_loader.cpp" />
+    <ClCompile Include="..\..\src\u_noise.c" />
+    <ClCompile Include="..\..\src\voxel_render.c" />
+    <ClCompile Include="..\..\src\win32\SDL_windows_main.c" />
+    <ClCompile Include="..\..\stb\stb_vorbis.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/vc12/obbg/obbg.vcxproj.filters
+++ b/vc12/obbg/obbg.vcxproj.filters
@@ -1,0 +1,117 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="src">
+      <UniqueIdentifier>{fd35fcf2-b6b6-4521-9fb9-5ddf5fc0fb16}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="stb">
+      <UniqueIdentifier>{c0461e5c-8e34-455c-85bf-6a4589d42c88}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\3rd">
+      <UniqueIdentifier>{5553d617-d699-42f4-a1cd-bfc21dc8d900}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\win32">
+      <UniqueIdentifier>{5f2f49cd-712a-4465-889f-1376355a74ed}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\stb\stb_perlin.h">
+      <Filter>stb</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\stb\stb_rect_pack.h">
+      <Filter>stb</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\stb\stb_textedit.h">
+      <Filter>stb</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\stb\stb_tilemap_editor.h">
+      <Filter>stb</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\stb\stb_truetype.h">
+      <Filter>stb</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\stb\stb_voxel_render.h">
+      <Filter>stb</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\stb\stretchy_buffer.h">
+      <Filter>stb</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\stb\stb.h">
+      <Filter>stb</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\stb\stb_c_lexer.h">
+      <Filter>stb</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\stb\stb_divide.h">
+      <Filter>stb</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\stb\stb_dxt.h">
+      <Filter>stb</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\stb\stb_easy_font.h">
+      <Filter>stb</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\stb\stb_herringbone_wang_tile.h">
+      <Filter>stb</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\stb\stb_image.h">
+      <Filter>stb</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\stb\stb_image_resize.h">
+      <Filter>stb</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\stb\stb_image_write.h">
+      <Filter>stb</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\stb\stb_leakcheck.h">
+      <Filter>stb</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\u_noise.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glext.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\glext_list.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\obbg_data.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\obbg_funcs.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\stb_gl.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\stb_glprog.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\3rd\crn_decomp.h">
+      <Filter>src\3rd</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\stb\stb_vorbis.c">
+      <Filter>stb</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\u_noise.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\voxel_render.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\mesh_builder.c">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\texture_loader.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\win32\SDL_windows_main.c">
+      <Filter>src\win32</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/vc12/obbg/obbg.vcxproj.user
+++ b/vc12/obbg/obbg.vcxproj.user
@@ -4,4 +4,8 @@
     <LocalDebuggerWorkingDirectory>$(SolutionDir)..\</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)..\</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
 </Project>

--- a/vc12/obbg/obbg.vcxproj.user
+++ b/vc12/obbg/obbg.vcxproj.user
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)..\</LocalDebuggerWorkingDirectory>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Compiles in both Debug and Release.  By default it expects SDL dependencies setup like in this picture.

![file setup](https://cloud.githubusercontent.com/assets/3078396/7657520/7f10da5e-fb00-11e4-978d-a14d8e463742.PNG)

Caveview sub-project isn't setup or included.
It seemed odd that u_noise.c should depend on caveview.h so I switched it for stb.h
